### PR TITLE
Feature/user-dashboard

### DIFF
--- a/src/app/features/user/user.routes.ts
+++ b/src/app/features/user/user.routes.ts
@@ -1,11 +1,11 @@
 import { Routes } from '@angular/router';
 
-import { authGuard } from '../../core';
+import { authGuard, roleGuard } from '../../core';
 
 export const userRoutes: Routes = [
   {
     path: '',
-    canActivate: [authGuard],
+    canActivate: [authGuard, roleGuard({ allowedRoles: ['user'] })],
     loadComponent: () => import('./layout/layout.component').then((m) => m.UserLayoutComponent),
     children: [
       {


### PR DESCRIPTION
- Add roleGuard with 'user' role restriction to user routes
- Prevents admin users from accessing /user/employees path
- Ensures proper role-based access control